### PR TITLE
Add GitHub source, repository and PR number parameters to CI scan command

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  pull_request:
+    branches: [ "*" ]
+  push:
+    branches: [ "main" ]
 jobs:
   ostorlab_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/action_with_extra.yaml
+++ b/.github/workflows/action_with_extra.yaml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  pull_request:
+    branches: [ "*" ]
+  push:
+    branches: [ "main" ]
 jobs:
   ostorlab_test:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Run Scan
       run: |
-        ostorlab --api-key="$INPUT_OSTORLAB_API_KEY" ci-scan run --log-flavor=github --title="$INPUT_SCAN_TITLE" --scan-profile="$INPUT_SCAN_PROFILE"  --break-on-risk-rating="$INPUT_BREAK_ON_RISK_RATING" --max-wait-minutes="$INPUT_MAX_WAIT_MINUTES" $INPUT_EXTRA $INPUT_ASSET_TYPE $INPUT_TARGET
+        ostorlab --api-key="$INPUT_OSTORLAB_API_KEY" ci-scan run --log-flavor=github --title="$INPUT_SCAN_TITLE" --scan-profile="$INPUT_SCAN_PROFILE" --break-on-risk-rating="$INPUT_BREAK_ON_RISK_RATING" --max-wait-minutes="$INPUT_MAX_WAIT_MINUTES" --source="github" --repository="$GITHUB_REPOSITORY" --pr-number="$GITHUB_PR_NUMBER" $INPUT_EXTRA $INPUT_ASSET_TYPE $INPUT_TARGET
       shell: bash
       env:
         INPUT_OSTORLAB_API_KEY: ${{ inputs.ostorlab_api_key }}
@@ -60,6 +60,8 @@ runs:
         INPUT_EXTRA: ${{ inputs.extra }}
         INPUT_ASSET_TYPE: ${{ inputs.asset_type }}
         INPUT_TARGET: ${{ inputs.target }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
 
 branding:
   icon: "shield"


### PR DESCRIPTION
This PR updates the GitHub Action configuration to pass the source, repository, and PR number parameters to match the Ostorlab CLI interface.